### PR TITLE
setting empty dial option for spicedb client connection

### DIFF
--- a/internal/data/spicedb.go
+++ b/internal/data/spicedb.go
@@ -24,8 +24,8 @@ func NewSpiceDbRepository(c *conf.Data, logger log.Logger) (*SpiceDbRepository, 
 	log.NewHelper(logger).Info("creating spicedb connection")
 
 	var opts []grpc.DialOption
-	opts = append(opts, grpc.WithBlock()) // TODO: always did it this way with authz. Still the right option?
-
+	opts = append(opts, grpc.EmptyDialOption{}) // TODO: always did it this way with authz. Still the right option?
+	//TODO: add a flag to enable/disable grpc.WithBlock
 	token := c.SpiceDb.Token
 	if token == "" {
 		err := fmt.Errorf("token is empty: %s", token)

--- a/spicedb/start-insights-rebac.sh
+++ b/spicedb/start-insights-rebac.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 set -e
-docker compose --env-file ./spicedb/.env --profile rebac -f ./docker-compose.yaml up -d --build
+# Function to check if a command is available
+source ./spicedb/check_docker_podman.sh
+
+${DOCKER} compose --env-file ./spicedb/.env --profile rebac -f ./docker-compose.yaml up -d --build

--- a/spicedb/start-spicedb.sh
+++ b/spicedb/start-spicedb.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 set -e
-docker-compose --env-file ./spicedb/.env -f ./docker-compose.yaml up -d
+# Function to check if a command is available
+source ./spicedb/check_docker_podman.sh
+${DOCKER} compose --env-file ./spicedb/.env -f ./docker-compose.yaml up -d

--- a/spicedb/teardown.sh
+++ b/spicedb/teardown.sh
@@ -4,6 +4,6 @@ source ./spicedb/check_docker_podman.sh
 
 set -e
 
-docker-compose --env-file ./spicedb/.env -f ./docker-compose.yaml down
+${DOCKER} compose --env-file ./spicedb/.env -f ./docker-compose.yaml down
 
 

--- a/spicedb/teardownrebac.sh
+++ b/spicedb/teardownrebac.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 set -e
-docker-compose --env-file ./spicedb/.env --profile rebac -f docker-compose.yaml down
+# Function to check if a command is available
+source ./spicedb/check_docker_podman.sh
+${DOCKER} compose --env-file ./spicedb/.env --profile rebac -f docker-compose.yaml down


### PR DESCRIPTION
### PR Template:

## Describe your changes

* Currently, when spicedb isn't available, client connection blocks the server to run. 
* Disabling grpc blocking would enable server to run for now.
* Migrating docker-compose to use docker compose(v2)

- ...

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

