### PR TITLE
Adds spicedb cluster resource to clowder template

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -3,6 +3,20 @@ kind: Template
 metadata:
   name: relationships
 objects:
+  - apiVersion: authzed.com/v1alpha1
+    kind: SpiceDBCluster
+    metadata:
+      name: ${CLOWDAPP_NAME}-spicedb
+    spec:
+      config:
+        datastoreEngine: memory
+      secretName: dev-spicedb-config
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: dev-spicedb-config
+    stringData:
+      preshared_key: "averysecretpresharedkey"
   - apiVersion: cloud.redhat.com/v1alpha1
     kind: ClowdApp
     metadata:


### PR DESCRIPTION
### PR Template:

## Describe your changes

- Adds spicedb cluster resource to clowder template.

## Ticket reference (if applicable)
Fixes: #RHCLOUD-31193

## Checklist

* [x] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [x] Do your changes have passing automated tests and sufficient observability?

* [x] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [x] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [x] Are the agreed upon coding/architectural practices applied?

* [x] Are security needs fullfilled? (e.g. no internal URL)

* [x] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [x] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

