### PR TITLE
Update deploy.sh to deploy rbac

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,3 +95,21 @@ The deploy script under the deploy folder, will deploy all the needed components
 
 You should be able to use the public route (relations-*) created by the clowder in your namespace, to use the service.
 
+#### Deploying the components with rbac
+
+This is demonstrating calling relationship api from rbac service in ephemeral environment.
+
+```
+./deploy.sh rbac <path_to_local_copy_of_insights_rbac>
+```
+
+`path_to_local_copy_of_insights_rbac` is this [repository](https://github.com/RedHatInsights/insights-rbac)
+
+Example:
+```
+./deploy.sh rbac /Users/liborpichler/Projects/insights-rbac
+```
+
+- Updates config bonfire file and add rbac component
+- Deploys rbac together with relationships application
+  - Hardcoded image is used with grpc client for calling relationships

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ This is demonstrating calling relationship api from rbac service in ephemeral en
 
 Example:
 ```
-./deploy.sh rbac /Users/liborpichler/Projects/insights-rbac
+./deploy.sh rbac /Projects/insights-rbac
 ```
 
 - Updates config bonfire file and add rbac component

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -3,7 +3,6 @@
 RBAC_ARGUMENT="$1"
 RBAC_DIR="$2"
 if [ "$RBAC_ARGUMENT" == "rbac" ]; then
-
  if [ ! -d "$RBAC_DIR" ]; then
     echo "The directory $RBAC_DIR does not exist."
     echo "Please specify local directory(absolute path) to copy of https://github.com/RedHatInsights/insights-rbac repository."
@@ -92,7 +91,7 @@ echo "postgress is ready"
 # Create spiceDB bootstrap schema configmap
 oc create configmap spicedb-schema --from-file=schema.yaml -n $NAMESPACE
 
-#Deploy Relations service, spiceDB service
+#Deploy Relations service, spiceDB service and rbac service when $RBAC_ARGUMENT is not empty
 bonfire deploy $RBAC_ARGUMENT relationships -n $NAMESPACE --local-config-method merge
 
 ROUTE=$(oc get routes --selector='app=relationships' -o jsonpath='{.items[*].spec.host}')


### PR DESCRIPTION
Changes:
- deploy script which is deploying also rbac
- readme file with mentioned changes

### How to run:

```
 ./deploy.sh rbac <path_to_local_copy_of_insights_rbac>
```

`path_to_local_copy_of_insights_rbac` is absolute path this [repository](https://github.com/RedHatInsights/insights-rbac)

Example:
```
./deploy.sh rbac /Users/liborpichler/Projects/insights-rbac
```

### Output

```
....bonfire output....

Route: XXXXX/api/authz/v1/relationships

user: XXXX
pass: XXXX

RBAC - status request consist creation of relations(image from PR https://github.com/RedHatInsights/insights-rbac/pull/1060)

curl -v -u xxxx:XXXX XXXX/api/rbac/v1/status/

Relations - Read(GET) - Sample CURL request

curl -v -u xxxx:XXXX XXXX 'XXXX/api/authz/v1/relationships?filter.objectType=group&filter.objectId=bob_club&filter.relation=member'

Relations - Write(POST) - Sample CURL request

curl -v -u xxxx:XXXX XXXX XXXXapi/authz/v1/relationships -d '{ touch: true, relationships: [{object: {type: group,id: bob_club},relation: member,subject: {object: {type: user,id: bob}}}]}'
```




### Links
https://issues.redhat.com/browse/RHCLOUD-31229


